### PR TITLE
fixed build badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 #Outstanding Cobra
-[![Build Status](https://semaphoreci.com/api/v1/outcobra/outstanding-cobra/branches/amend-auth-filter/badge.svg)](https://semaphoreci.com/outcobra/outstanding-cobra)
+
+[![Build Status](https://semaphoreci.com/api/v1/outcobra/outstanding-cobra/branches/develop/shields_badge.svg)](https://semaphoreci.com/outcobra/outstanding-cobra)
 [![CircleCI](https://circleci.com/gh/outcobra/outstanding-cobra.svg?style=svg)](https://circleci.com/gh/outcobra/outstanding-cobra)
-[![Build Status](https://travis-ci.org/outcobra/outstanding-cobra.svg?branch=develop)](https://travis-ci.org/outcobra/outstanding-cobra)
 [![codebeat badge](https://codebeat.co/badges/d8dd9a81-a229-46e3-b5b2-d016ca70cfa4)](https://codebeat.co/projects/github-com-outcobra-outstanding-cobra)
 
 # Installation


### PR DESCRIPTION
This closes none .

Summary of changes:
- ​remove travis badge
- semaphore-badge is now pointing at develop


I made sure to:

- [x] Update any documentation (javadoc, domain model, erd, ...)
- [x] Follow the contribution guidelines



Please review @jmesserli / cc: @outcobra/developers.