### PR TITLE
set endpoint sensitivity to false for dev profile

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -17,6 +17,7 @@ spring.profiles: development
 #ignore the ugliness bc it doesn't seem to work in a different way
 endpoints:
   enabled: true
+  sensitive: false
 spring:
   profiles:
     include: load_test_data,h2_db


### PR DESCRIPTION
This closes #247 

Summary of changes:
- ​access to all actuator endpoints is now enabled by default when the development profile is active

I made sure to:
- [x] Add and / or update tests
- [x] Run the code formatter (`CTRL + ALT + L`)
- [x] Update any documentation (javadoc, domain model, erd, ...)
- [x] Follow the contribution guidelines
- [x] Update CI script and configs on Jenkins (`Jenkinsfile`, `auth0.yml`, `application.yml`, etc.)

Please review @jmesserli  / cc: @outcobra/developers.