### PR TITLE
do only import rxjs/Observable and move operators to new file

### DIFF
--- a/frontend/build.gradle
+++ b/frontend/build.gradle
@@ -1,4 +1,3 @@
-/*
 plugins {
     id "com.moowork.node" version "1.0.1"
 }
@@ -22,4 +21,3 @@ task ngTest(type: YarnTask, dependsOn: yarn_install) {
     args = ['run', 'ng', 'test', '--', '--watch=false', '--single-run', '--browser=PhantomJS']
 }
 task test(dependsOn: ngTest)
-*/

--- a/frontend/build.gradle
+++ b/frontend/build.gradle
@@ -1,3 +1,4 @@
+/*
 plugins {
     id "com.moowork.node" version "1.0.1"
 }
@@ -21,3 +22,4 @@ task ngTest(type: YarnTask, dependsOn: yarn_install) {
     args = ['run', 'ng', 'test', '--', '--watch=false', '--single-run', '--browser=PhantomJS']
 }
 task test(dependsOn: ngTest)
+*/

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -4,7 +4,6 @@ import {BrowserModule} from '@angular/platform-browser';
 import {Http, HttpModule} from '@angular/http';
 import {MdNativeDateModule} from '@angular/material';
 import {TranslateLoader, TranslateModule, TranslateService} from '@ngx-translate/core';
-import 'rxjs/add/operator/toPromise';
 import {AppComponent} from './app.component';
 import {ConfigService} from './core/config/config.service';
 import {SharedModule} from './shared/shared.module';

--- a/frontend/src/app/core/http/http-interceptor.ts
+++ b/frontend/src/app/core/http/http-interceptor.ts
@@ -1,8 +1,7 @@
 import {Injectable} from '@angular/core';
 import {Http, Request, RequestMethod, Response, URLSearchParams} from '@angular/http';
 import {ConfigService} from '../config/config.service';
-import {Observable} from 'rxjs';
-import 'rxjs/add/operator/map';
+import {Observable} from 'rxjs/Observable';
 import {dateReplacer} from './http-util';
 import {RequestOptions} from './request-options';
 import {ValidationException} from './validation-exception';

--- a/frontend/src/app/core/interfaces/cacheable.ts
+++ b/frontend/src/app/core/interfaces/cacheable.ts
@@ -1,4 +1,4 @@
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 
 /**
  * interface which defines all methods for a service which can cache the type T

--- a/frontend/src/app/core/mock/manage/mock-manage.service.ts
+++ b/frontend/src/app/core/mock/manage/mock-manage.service.ts
@@ -1,6 +1,6 @@
 import {Injectable} from '@angular/core';
 import {ManageService} from '../../../manage/service/manage.service';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 import {ManageDto} from '../../../manage/model/manage.dto';
 import {InstitutionService} from '../../../manage/service/institution.service';
 

--- a/frontend/src/app/core/mock/mock-color.service.ts
+++ b/frontend/src/app/core/mock/mock-color.service.ts
@@ -1,5 +1,5 @@
 import {Injectable} from '@angular/core';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 import {ColorService} from '../services/color.service';
 import {ColorDto} from '../model/color.dto';
 

--- a/frontend/src/app/core/notifications/notification-wrapper.service.ts
+++ b/frontend/src/app/core/notifications/notification-wrapper.service.ts
@@ -1,7 +1,6 @@
 import {Injectable} from '@angular/core';
 import {NotificationsService} from 'angular2-notifications';
 import {TranslateService} from '@ngx-translate/core';
-import 'rxjs/add/operator/toPromise';
 import {appIcons} from './icons';
 import {Icons, Notification} from 'angular2-notifications/dist';
 

--- a/frontend/src/app/core/services/auth/auth.service.ts
+++ b/frontend/src/app/core/services/auth/auth.service.ts
@@ -4,7 +4,7 @@ import {tokenNotExpired} from 'angular2-jwt';
 import {Router} from '@angular/router';
 import {HttpInterceptor} from '../../http/http-interceptor';
 import {Util} from '../../util/util';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 import {User} from '../../model/user';
 import {TranslateService} from '@ngx-translate/core';
 import {NotificationWrapperService} from '../../notifications/notification-wrapper.service';

--- a/frontend/src/app/core/services/color.service.ts
+++ b/frontend/src/app/core/services/color.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {HttpInterceptor} from '../http/http-interceptor';
 import {ColorDto} from '../model/color.dto';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 import {CacheableService} from './core/cacheable.service';
 
 @Injectable()

--- a/frontend/src/app/core/services/confirm-dialog.service.ts
+++ b/frontend/src/app/core/services/confirm-dialog.service.ts
@@ -1,6 +1,6 @@
 import {Injectable} from '@angular/core';
 import {MdDialog} from '@angular/material';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 import {ResponsiveHelperService} from './ui/responsive-helper.service';
 import {SMALL_DIALOG} from '../util/const';
 import {ConfirmDialogComponent} from '../../shared/components/confirm-dialog/confirm-dialog.component';

--- a/frontend/src/app/core/services/core/app-crud.service.ts
+++ b/frontend/src/app/core/services/core/app-crud.service.ts
@@ -1,6 +1,6 @@
 import {AppService} from './app.service';
 import {CrudService} from './crud.service';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 
 /**
  * Basic implementation of a CrudAppService which connects to the default api

--- a/frontend/src/app/core/services/core/cacheable-crud.service.ts
+++ b/frontend/src/app/core/services/core/cacheable-crud.service.ts
@@ -1,5 +1,5 @@
 import {CrudService} from './crud.service';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 import {CacheableService} from './cacheable.service';
 
 /**

--- a/frontend/src/app/core/services/core/cacheable.service.ts
+++ b/frontend/src/app/core/services/core/cacheable.service.ts
@@ -1,5 +1,5 @@
 import {Cacheable} from '../../interfaces/cacheable';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 import {Util} from '../../util/util';
 import {HttpInterceptor} from '../../http/http-interceptor';
 import {AppService} from './app.service';

--- a/frontend/src/app/core/services/core/crud.service.ts
+++ b/frontend/src/app/core/services/core/crud.service.ts
@@ -1,4 +1,4 @@
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 
 /**
  * Interface for services that implement simple crud functionality

--- a/frontend/src/app/core/services/filter/subject.filter.resolver.service.ts
+++ b/frontend/src/app/core/services/filter/subject.filter.resolver.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {ActivatedRouteSnapshot, Resolve, RouterStateSnapshot} from '@angular/router';
 import {SubjectFilterDto} from '../../../task/model/subject.filter.dto';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 import {FilterService} from './filter.service';
 
 @Injectable()

--- a/frontend/src/app/core/services/info.service.ts
+++ b/frontend/src/app/core/services/info.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {AppService} from './core/app.service';
 import {HttpInterceptor} from '../http/http-interceptor';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 import {Info} from '../model/info.dto';
 
 @Injectable()

--- a/frontend/src/app/core/services/ui/responsive-helper.service.ts
+++ b/frontend/src/app/core/services/ui/responsive-helper.service.ts
@@ -1,5 +1,5 @@
 import {Injectable} from '@angular/core';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 import {MOBILE_DIALOG} from '../../util/const';
 import {MdDialogConfig} from '@angular/material';
 import {Orientation} from './orientation';

--- a/frontend/src/app/manage/manage.component.ts
+++ b/frontend/src/app/manage/manage.component.ts
@@ -17,7 +17,7 @@ import {SubjectDialog} from './subject-dialog/subject-dialog.component';
 import {SubjectService} from './service/subject.service';
 import {Util} from '../core/util/util';
 import {equals, isFalsy, isNotNull, isTrue, isTruthy} from '../core/util/helper';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 import {Dto} from '../core/common/dto';
 import {CreateUpdateComponent} from '../core/common/create-update-component';
 import {ResponsiveHelperService} from '../core/services/ui/responsive-helper.service';

--- a/frontend/src/app/manage/service/institution.service.ts
+++ b/frontend/src/app/manage/service/institution.service.ts
@@ -1,6 +1,6 @@
 import {Injectable} from '@angular/core';
 import {HttpInterceptor} from '../../core/http/http-interceptor';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 import {InstitutionDto} from '../model/manage.dto';
 import {AppCrudService} from '../../core/services/core/app-crud.service';
 

--- a/frontend/src/app/manage/service/manage.service.ts
+++ b/frontend/src/app/manage/service/manage.service.ts
@@ -1,6 +1,6 @@
 import {Injectable} from '@angular/core';
 import {HttpInterceptor} from '../../core/http/http-interceptor';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 import {ManageDto} from '../model/manage.dto';
 import {AppService} from '../../core/services/core/app.service';
 

--- a/frontend/src/app/manage/service/school-class.service.ts
+++ b/frontend/src/app/manage/service/school-class.service.ts
@@ -1,6 +1,6 @@
 import {Injectable} from '@angular/core';
 import {HttpInterceptor} from '../../core/http/http-interceptor';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 import {SchoolClassDto} from '../model/manage.dto';
 import {AppCrudService} from '../../core/services/core/app-crud.service';
 

--- a/frontend/src/app/manage/service/school-year.service.ts
+++ b/frontend/src/app/manage/service/school-year.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {HttpInterceptor} from '../../core/http/http-interceptor';
 import {SchoolYearDto} from '../model/manage.dto';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 import {AppCrudService} from '../../core/services/core/app-crud.service';
 
 @Injectable()

--- a/frontend/src/app/manage/service/semester.service.ts
+++ b/frontend/src/app/manage/service/semester.service.ts
@@ -1,6 +1,6 @@
 import {Injectable} from '@angular/core';
 import {HttpInterceptor} from '../../core/http/http-interceptor';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 import {SemesterDto} from '../model/manage.dto';
 import {AppCrudService} from '../../core/services/core/app-crud.service';
 import {DateUtil} from '../../core/services/date-util.service';

--- a/frontend/src/app/manage/service/subject.service.ts
+++ b/frontend/src/app/manage/service/subject.service.ts
@@ -1,6 +1,6 @@
 import {Injectable} from '@angular/core';
 import {HttpInterceptor} from '../../core/http/http-interceptor';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 import {SubjectDto} from '../model/manage.dto';
 import {AppCrudService} from '../../core/services/core/app-crud.service';
 

--- a/frontend/src/app/task/service/task-detail-resolver.service.ts
+++ b/frontend/src/app/task/service/task-detail-resolver.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {ActivatedRouteSnapshot, Resolve, Router, RouterStateSnapshot} from '@angular/router';
 import {TaskDto} from '../model/task.dto';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 import {TaskService} from './task.service';
 import {HttpStatus} from '../../core/http/http-status';
 import {NotificationWrapperService} from '../../core/notifications/notification-wrapper.service';

--- a/frontend/src/app/task/service/task-list-resolver.service.ts
+++ b/frontend/src/app/task/service/task-list-resolver.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {ActivatedRouteSnapshot, Resolve, RouterStateSnapshot} from '@angular/router';
 import {TaskDto} from '../model/task.dto';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 import {TaskService} from './task.service';
 
 @Injectable()

--- a/frontend/src/app/task/service/task.service.ts
+++ b/frontend/src/app/task/service/task.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {HttpInterceptor} from '../../core/http/http-interceptor';
 import {TaskDto} from '../model/task.dto';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 import {CacheableCrudService} from '../../core/services/core/cacheable-crud.service';
 import {TaskProgressUpdateDto} from '../model/task.update.progress.dto';
 

--- a/frontend/src/app/task/task-detail-component/task-detail.component.ts
+++ b/frontend/src/app/task/task-detail-component/task-detail.component.ts
@@ -7,7 +7,7 @@ import {MdDialog, MdDialogRef, MdSlider, MdSliderChange} from '@angular/material
 import {TaskCreateUpdateDialog} from '../task-create-update-dialog/task-create-update-dialog.component';
 import {SMALL_DIALOG} from '../../core/util/const';
 import {ViewMode} from '../../core/common/view-mode';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 import {isTrue, isTruthy} from '../../core/util/helper';
 import {NotificationWrapperService} from '../../core/notifications/notification-wrapper.service';
 import {DurationService} from '../../core/services/duration.service';

--- a/frontend/src/app/task/task.component.ts
+++ b/frontend/src/app/task/task.component.ts
@@ -8,7 +8,7 @@ import {MdDialog, MdDialogRef} from '@angular/material';
 import {TaskCreateUpdateDialog} from './task-create-update-dialog/task-create-update-dialog.component';
 import {Util} from '../core/util/util';
 import {ViewMode} from '../core/common/view-mode';
-import {Observable} from 'rxjs';
+import {Observable} from 'rxjs/Observable';
 import {SMALL_DIALOG} from '../core/util/const';
 import {and} from '../core/util/helper';
 import {ResponsiveHelperService} from '../core/services/ui/responsive-helper.service';

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,6 +2,7 @@ import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {enableProdMode} from '@angular/core';
 import {environment} from './environments/environment';
 import {AppModule} from './app/';
+import './rx-operators'
 import 'hammerjs';
 
 if (environment.production) {

--- a/frontend/src/rx-operators.ts
+++ b/frontend/src/rx-operators.ts
@@ -1,0 +1,9 @@
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/switchMap';
+import 'rxjs/add/operator/catch';
+import 'rxjs/add/operator/distinctUntilChanged';
+import 'rxjs/add/operator/debounceTime';
+import 'rxjs/add/operator/skipWhile';
+import 'rxjs/add/operator/toPromise';
+import 'rxjs/add/observable/combineLatest';
+import 'rxjs/add/observable/empty';

--- a/frontend/src/test.ts
+++ b/frontend/src/test.ts
@@ -5,6 +5,7 @@ import 'zone.js/dist/jasmine-patch';
 import 'zone.js/dist/async-test';
 import 'zone.js/dist/fake-async-test';
 import 'intl/locale-data/jsonp/en.js';
+import './rx-operators';
 import 'hammerjs';
 
 // Unfortunately there's no typing for the `__karma__` variable. Just declare it as any.


### PR DESCRIPTION
This closes niente and nada

Summary of changes:
- ​import Observable from `rxjs/Observable` instead of just `rxjs`
- import used operators only

I made sure to:
- [x] Add and / or update tests
- [x] Run the code formatter (`CTRL + ALT + L`)
- [x] Update any documentation (javadoc, domain model, erd, ...)
- [x] Follow the contribution guidelines
- [x] Update CI script and configs on Jenkins (`Jenkinsfile`, `auth0.yml`, `application.yml`, etc.)

Please review @jmesserli  / cc: @outcobra/developers.