### PR TITLE
Amend/refactor oc icon data to match mat specs

### DIFF
--- a/frontend/src/app/exam/exam-list-item/exam-list-item.component.html
+++ b/frontend/src/app/exam/exam-list-item/exam-list-item.component.html
@@ -1,36 +1,40 @@
 <div class="form-group">
     <oc-icon-data iconName="title"
                   titleKey="i18n.modules.exam.name">
-        <p class="exam-property">{{ exam.name }}</p>
+        <span class="exam-property">{{ exam.name }}</span>
     </oc-icon-data>
     <oc-icon-data *ngIf="exam.description?.length"
                   iconName="description"
                   titleKey="i18n.modules.exam.description">
-        <p class="exam-property">{{ exam.description }}</p>
+        <span class="exam-property">{{ exam.description }}</span>
     </oc-icon-data>
     <oc-icon-data iconName="today"
                   titleKey="i18n.common.label.dueDate"
                   [showDivider]="exam.mark != null || exam.examTasks?.length">
-        <p class="exam-property">{{ exam.date | date:'fullDate' }}</p>
+        <span class="exam-property">{{ exam.date | date:'fullDate' }}</span>
     </oc-icon-data>
     <oc-icon-data iconName="poll"
                   titleKey="i18n.modules.exam.mark.title"
                   [showDivider]="exam.examTasks?.length"
                   *ngIf="exam.mark">
-        <p class="exam-property">{{ exam.mark.value | markValue }}</p>
+        <span class="exam-property">{{ exam.mark.value | markValue }}</span>
     </oc-icon-data>
     <oc-icon-data *ngIf="exam.examTasks?.length"
                   iconName="assignment_turned_in"
                   titleKey="i18n.modules.exam.examTask.title"
                   [showDivider]="false">
-        <mat-list>
-            <mat-list-item *ngFor="let examTask of exam.examTasks">
-                <mat-checkbox class="exam-property" [checked]="examTask.finished"
-                             (change)="finishTask$.next(examTask.id)">
-                    {{ examTask.task }}
-                </mat-checkbox>
-            </mat-list-item>
-        </mat-list>
+        <oc-icon-data-child>
+            <oc-icon-data-data>
+                <mat-list>
+                    <mat-list-item *ngFor="let examTask of exam.examTasks">
+                        <mat-checkbox class="exam-property" [checked]="examTask.finished"
+                                      (change)="finishTask$.next(examTask.id)">
+                            {{ examTask.task }}
+                        </mat-checkbox>
+                    </mat-list-item>
+                </mat-list>
+            </oc-icon-data-data>
+        </oc-icon-data-child>
     </oc-icon-data>
 </div>
 <button mat-button

--- a/frontend/src/app/exam/exam-list-item/exam-list-item.component.scss
+++ b/frontend/src/app/exam/exam-list-item/exam-list-item.component.scss
@@ -1,0 +1,3 @@
+:host mat-list {
+  padding-top: 0;
+}

--- a/frontend/src/app/exam/exam-list-item/exam-list-item.component.ts
+++ b/frontend/src/app/exam/exam-list-item/exam-list-item.component.ts
@@ -3,7 +3,6 @@ import {ExamDto} from '../model/exam.dto';
 import {ExamTaskService} from '../service/exam-task.service';
 import {Subject} from 'rxjs/Subject';
 import {ExamTaskDto} from '../model/exam.task.dto';
-import {Util} from '../../core/util/util';
 
 @Component({
     selector: 'exam-list-item',
@@ -23,16 +22,11 @@ export class ExamListItemComponent implements OnInit {
 
     ngOnInit() {
         this.finishTask$
-            .subscribe(id => {
-                this._examTaskService.changeState(id)
-                    .subscribe((examTask: ExamTaskDto) => {
-                        this._updateExamTaskList(examTask)
-                    })
-            });
+            .switchMap(id => this._examTaskService.changeState(id))
+            .subscribe(examTask => this._updateExamTaskList(examTask));
     }
 
     private _updateExamTaskList(examTask: ExamTaskDto) {
-        Util.removeFirstMatch(this.exam.examTasks, (item: ExamTaskDto) => item.id == examTask.id)
-        this.exam.examTasks.push(examTask)
+        this.exam.examTasks.find(et => et.id == examTask.id).finished = examTask.finished;
     }
 }

--- a/frontend/src/app/oc-ui/components/oc-icon-data/oc-icon-data-child/oc-icon-data-child.component.html
+++ b/frontend/src/app/oc-ui/components/oc-icon-data/oc-icon-data-child/oc-icon-data-child.component.html
@@ -1,8 +1,8 @@
-<div class="subtitle">
-    <label class="data-title">
-        <ng-content select="oc-icon-data-title"></ng-content>
-    </label>
-</div>
 <div class="data">
     <ng-content select="oc-icon-data-data"></ng-content>
+</div>
+<div class="subtitle">
+    <label class="text-secondary-dark data-title">
+        <ng-content select="oc-icon-data-title"></ng-content>
+    </label>
 </div>

--- a/frontend/src/app/oc-ui/components/oc-icon-data/oc-icon-data-child/oc-icon-data-child.component.scss
+++ b/frontend/src/app/oc-ui/components/oc-icon-data/oc-icon-data-child/oc-icon-data-child.component.scss
@@ -1,6 +1,0 @@
-@import '../../../../../sass/color-variables';
-
-.subtitle {
-    font-weight: normal !important;
-    color: $secondary-dark;
-}

--- a/frontend/src/app/oc-ui/components/oc-icon-data/oc-icon-data-child/oc-icon-data-child.component.spec.ts
+++ b/frontend/src/app/oc-ui/components/oc-icon-data/oc-icon-data-child/oc-icon-data-child.component.spec.ts
@@ -3,23 +3,23 @@ import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {OCIconDataChildComponent} from './oc-icon-data-child.component';
 
 describe('OCIconDataChildComponent', () => {
-  let component: OCIconDataChildComponent;
-  let fixture: ComponentFixture<OCIconDataChildComponent>;
+    let component: OCIconDataChildComponent;
+    let fixture: ComponentFixture<OCIconDataChildComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ OCIconDataChildComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [OCIconDataChildComponent]
+        })
+            .compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(OCIconDataChildComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(OCIconDataChildComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/frontend/src/app/oc-ui/components/oc-icon-data/oc-icon-data-child/oc-icon-data-child.component.ts
+++ b/frontend/src/app/oc-ui/components/oc-icon-data/oc-icon-data-child/oc-icon-data-child.component.ts
@@ -3,7 +3,6 @@ import {Component, ViewEncapsulation} from '@angular/core';
 @Component({
     selector: 'oc-icon-data-child',
     templateUrl: './oc-icon-data-child.component.html',
-    styleUrls: ['./oc-icon-data-child.component.scss'],
     encapsulation: ViewEncapsulation.None
 })
 export class OCIconDataChildComponent {

--- a/frontend/src/app/oc-ui/components/oc-icon-data/oc-icon-data/oc-icon-data.component.html
+++ b/frontend/src/app/oc-ui/components/oc-icon-data/oc-icon-data/oc-icon-data.component.html
@@ -1,15 +1,13 @@
-<div class="title" fxLayout>
-    <div fxFlex="10">
+<div fxLayout>
+    <div class="icon">
         <mat-icon>{{ iconName }}</mat-icon>
     </div>
-    <div fxFlex>
+    <div class="data" fxLayout="column" [ngClass]="{'multi-child': getDataOrder()}">
+        <div class="data-wrapper" [fxFlexOrder]="getDataOrder()">
+            <ng-content></ng-content>
+        </div>
         <label class="text-secondary-dark data-title">
             {{ titleKey | translate}}
         </label>
-    </div>
-</div>
-<div class="data end" fxLayout>
-    <div fxFlex="90" fxFlexOffset="10">
-        <ng-content></ng-content>
     </div>
 </div>

--- a/frontend/src/app/oc-ui/components/oc-icon-data/oc-icon-data/oc-icon-data.component.scss
+++ b/frontend/src/app/oc-ui/components/oc-icon-data/oc-icon-data/oc-icon-data.component.scss
@@ -1,25 +1,56 @@
 @import '../../../../../sass/color-variables';
 
-:host {
-    display: block;
-    margin-bottom: 12px;
+$icon-data-height: 72px;
+$icon-data-icon-max-width: 72px;
 
-    &.title, &.subtitle {
-        margin: 0;
-        font-weight: 500;
-        label.data-title {
-            line-height: 28px;
-        }
+:host {
+    .icon {
+        height: $icon-data-height;
+        max-height: $icon-data-height;
+        display: flex;
+        align-items: center;
+        padding-left: 16px;
+        width: $icon-data-icon-max-width;
+        max-width: $icon-data-icon-max-width;
     }
-    &.data {
-        margin-bottom: 10px;
-        p {
-            margin: 10px 0;
+
+    .data {
+        min-height: $icon-data-height;
+        padding-right: 16px;
+        display: flex;
+        justify-content: center;
+        flex-grow: 1;
+
+        .data-wrapper, ::ng-deep oc-icon-data-data, ::ng-deep oc-icon-data-title {
+            > span, > p {
+                margin: 0;
+                padding: 0;
+                font-size: 16px;
+            }
+        }
+
+        .data-title {
+            font-size: 14px;
+        }
+
+        &.multi-child {
+            .data-title {
+                font-size: 18px;
+                height: $icon-data-height;
+                line-height: $icon-data-height;
+            }
+
+            .data-wrapper ::ng-deep oc-icon-data-child {
+                display: flex;
+                flex-direction: column;
+                justify-content: center;
+                min-height: $icon-data-height !important;
+            }
         }
     }
 
     &.show-divider {
-        div.data.end {
+        .data {
             border-bottom: 1px solid $slightly-dark;
         }
     }

--- a/frontend/src/app/oc-ui/components/oc-icon-data/oc-icon-data/oc-icon-data.component.spec.ts
+++ b/frontend/src/app/oc-ui/components/oc-icon-data/oc-icon-data/oc-icon-data.component.spec.ts
@@ -2,6 +2,7 @@ import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {OCIconDataComponent} from './oc-icon-data.component';
 import {TestModule} from '../../../../core/mock/test.module';
+import {FlexLayoutModule} from '@angular/flex-layout';
 
 describe('OCIconDataComponent', () => {
     let component: OCIconDataComponent;
@@ -13,7 +14,8 @@ describe('OCIconDataComponent', () => {
                 OCIconDataComponent
             ],
             imports: [
-                TestModule
+                TestModule,
+                FlexLayoutModule
             ]
         }).compileComponents();
     }));

--- a/frontend/src/app/oc-ui/components/oc-icon-data/oc-icon-data/oc-icon-data.component.ts
+++ b/frontend/src/app/oc-ui/components/oc-icon-data/oc-icon-data/oc-icon-data.component.ts
@@ -1,13 +1,21 @@
-import {Component, HostBinding, Input} from '@angular/core';
+import {Component, ContentChild, HostBinding, Input, ViewEncapsulation} from '@angular/core';
+import {OCIconDataChildComponent} from '../oc-icon-data-child/oc-icon-data-child.component';
+import {isTruthy} from '../../../../core/util/helper';
 
 @Component({
     selector: 'oc-icon-data',
     templateUrl: './oc-icon-data.component.html',
-    styleUrls: ['./oc-icon-data.component.scss']
+    styleUrls: ['./oc-icon-data.component.scss'],
+    encapsulation: ViewEncapsulation.Emulated
 })
 export class OCIconDataComponent {
     @Input() public iconName: string;
     @Input() public titleKey: string;
     @HostBinding('class.show-divider')
     @Input() public showDivider: boolean = true;
+    @ContentChild(OCIconDataChildComponent) child: OCIconDataChildComponent;
+
+    public getDataOrder() {
+        return isTruthy(this.child) ? 1 : 0;
+    }
 }

--- a/frontend/src/app/task/task-detail-component/task-detail.component.html
+++ b/frontend/src/app/task/task-detail-component/task-detail.component.html
@@ -1,31 +1,33 @@
-<!-- TASK DESC START-->
-<oc-icon-data iconName="description" titleKey="i18n.modules.task.desc">
-    <p class="task-property">{{ task.description }}</p>
-</oc-icon-data>
-<!-- TASK DESC END -->
-<!-- TASK TODO_DATE START -->
-<oc-icon-data iconName="alarm" titleKey="i18n.common.label.todoDate">
-    <p class="task-property">{{ task.todoDate | date:'fullDate' }}</p>
-</oc-icon-data>
-<!-- TASK TODO_DATE END -->
-<!-- TASK DUE_DATE START-->
-<oc-icon-data iconName="event" titleKey="i18n.common.label.dueDate">
-    <p class="task-property">{{ task.dueDate | date:'fullDate' }}</p>
-</oc-icon-data>
-<!-- TASK DUE_DATE END-->
-<!-- TASK PROGRESS START-->
-<oc-icon-data iconName="show_chart" titleKey="i18n.modules.task.progress">
-    <div class="row task-progress" fxLayout>
-        <div class="col s1 progress-value" fxFlex="15">{{ task.progress }}%</div>
-        <div class="col s11" fxFlex>
-            <mat-slider [(ngModel)]="task.progress" color="accent" thumbLabel step="5"></mat-slider>
+<div class="task-detail">
+    <!-- TASK DESC START-->
+    <oc-icon-data iconName="description" titleKey="i18n.modules.task.desc">
+        <span class="task-property">{{ task.description }}</span>
+    </oc-icon-data>
+    <!-- TASK DESC END -->
+    <!-- TASK TODO_DATE START -->
+    <oc-icon-data iconName="alarm" titleKey="i18n.common.label.todoDate">
+        <span class="task-property">{{ task.todoDate | date:'fullDate' }}</span>
+    </oc-icon-data>
+    <!-- TASK TODO_DATE END -->
+    <!-- TASK DUE_DATE START-->
+    <oc-icon-data iconName="event" titleKey="i18n.common.label.dueDate">
+        <span class="task-property">{{ task.dueDate | date:'fullDate' }}</span>
+    </oc-icon-data>
+    <!-- TASK DUE_DATE END-->
+    <!-- TASK PROGRESS START-->
+    <oc-icon-data iconName="show_chart" titleKey="i18n.modules.task.progress">
+        <div class="row task-progress" fxLayout>
+            <div class="col s1 progress-value" fxFlex="15">{{ task.progress }}%</div>
+            <div class="col s11" fxFlex>
+                <mat-slider [(ngModel)]="task.progress" color="accent" thumbLabel step="5"></mat-slider>
+            </div>
         </div>
-    </div>
-</oc-icon-data>
-<oc-icon-data iconName="timelapse" titleKey="i18n.modules.task.dialogs.add.effort.remaining">
-    <p class="task-property">{{ getRemainingEffort() }}</p>
-</oc-icon-data>
-<!-- TASK PROGRESS END-->
+    </oc-icon-data>
+    <oc-icon-data iconName="timelapse" titleKey="i18n.modules.task.dialogs.add.effort.remaining">
+        <span class="task-property">{{ getRemainingEffort() }}</span>
+    </oc-icon-data>
+    <!-- TASK PROGRESS END-->
+</div>
 <button mat-button
         color="primary"
         (click)="editTask()">

--- a/frontend/src/app/task/task-detail-component/task-detail.component.scss
+++ b/frontend/src/app/task/task-detail-component/task-detail.component.scss
@@ -1,8 +1,11 @@
 @import '../../../sass/color-variables';
 
 :host {
-    padding: 16px 24px;
     display: block;
+
+    .task-detail {
+        margin-bottom: 16px;
+    }
 }
 
 .task-progress {

--- a/frontend/src/app/task/task-list-item-header/task-list-item-header.component.scss
+++ b/frontend/src/app/task/task-list-item-header/task-list-item-header.component.scss
@@ -6,8 +6,6 @@ task-list-item-header {
     .task-list-item-header-wrapper {
         display: flex;
         align-items: center;
-        height: 56px;
-        padding: 0 12px;
 
         .subject-letter-icon {
             border-radius: 50%;


### PR DESCRIPTION
Nothing is closed by this

Summary of changes:
I thought that I'd could change the oc-icon-data to match the specs.
Look [here](https://material.io/guidelines/components/lists.html#lists-specs)

I made sure to:
- [x] Add and / or update tests
- [x] Run the code formatter (`CTRL + ALT + L`)
- [x] Update any documentation (javadoc, domain model, erd, ...)
- [x] Follow the contribution guidelines
- [x] Update CI script and configs on Jenkins (`Jenkinsfile`, `auth0.yml`, `application.yml`, etc.)

Please review @**todo** / cc: @outcobra/developers.