### PR TITLE
Amend/#317 yarn gradle cache ci

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent {
         docker {
             image 'jmesserli/openjdk-with-docker'
-            args '-v /var/run/docker.sock:/var/run/docker.sock -v /opt/jenkins-agent/persist/gradle:~/.gradle -v /opt/jenkins-agent/persist/yarn:/root/yarn-cache'
+            args '-v /var/run/docker.sock:/var/run/docker.sock -v /opt/jenkins-agent/persist/gradle:/root/.gradle -v /opt/jenkins-agent/persist/yarn:/root/yarn-cache'
         }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
     stages {
         stage('Prepare') {
             steps {
-                sh 'chmod +x gradlew && mkdir /root/yarn-cache'
+                sh 'chmod +x gradlew'
                 script {
                     configFileProvider([
                             configFile(fileId: '2bc843a4-052f-4a68-9f8a-8b2cb9d2c16c', targetLocation: 'backend/src/main/resources/auth0.yml'),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
     stages {
         stage('Prepare') {
             steps {
-                sh 'chmod +x gradlew'
+                sh 'chmod +x gradlew && mkdir /root/yarn-cache'
                 script {
                     configFileProvider([
                             configFile(fileId: '2bc843a4-052f-4a68-9f8a-8b2cb9d2c16c', targetLocation: 'backend/src/main/resources/auth0.yml'),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent {
         docker {
             image 'jmesserli/openjdk-with-docker'
-            args '-v /var/run/docker.sock:/var/run/docker.sock'
+            args '-v /var/run/docker.sock:/var/run/docker.sock -v /opt/jenkins-agent/persist/gradle:~/.gradle -v /opt/jenkins-agent/persist/yarn:/root/yarn-cache'
         }
     }
 
@@ -26,7 +26,7 @@ pipeline {
                             sh './gradlew clean :backend:assemble --stacktrace --info'
                         },
                         "Build Frontend": {
-                            sh './gradlew :frontend:assemble --stacktrace --info'
+                            sh './gradlew :frontend:setCacheFolderCI :frontend:assemble --stacktrace --info'
                         }
                 )
             }

--- a/frontend/build.gradle
+++ b/frontend/build.gradle
@@ -20,3 +20,7 @@ task ngTest(type: YarnTask, dependsOn: yarn_install) {
     args = ['run', 'ng', 'test', '--watch=false', '--single-run', '--browser=PhantomJS', '--code-coverage']
 }
 task test(dependsOn: ngTest)
+
+task setCacheFolderCI(type: YarnTask) {
+    args = ['config', 'set', 'cache-folder', '~/yarn-cache']
+}

--- a/frontend/build.gradle
+++ b/frontend/build.gradle
@@ -22,5 +22,5 @@ task ngTest(type: YarnTask, dependsOn: yarn_install) {
 task test(dependsOn: ngTest)
 
 task setCacheFolderCI(type: YarnTask) {
-    args = ['config', 'set', 'cache-folder', '~/yarn-cache']
+    args = ['config', 'set', 'cache-folder', '/root/yarn-cache']
 }


### PR DESCRIPTION
This closes #317.

Summary of changes:
- ​Map yarn and gradle caches to speed up build times

Please review @M4R1KU / cc: @outcobra/developers.