### PR TITLE
added -_£{}[]!*#/\:.;? to the list of special chars

### DIFF
--- a/frontend/src/app/core/services/oc-validators.ts
+++ b/frontend/src/app/core/services/oc-validators.ts
@@ -10,7 +10,7 @@ import {isTrue} from '../util/helper';
 import {Observable} from 'rxjs/Observable';
 
 export class OCValidators {
-    public static readonly PASSWORD_REGEX: RegExp = /^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+=])(?=\S+$).{8,}$/;
+    public static readonly PASSWORD_REGEX: RegExp = /^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[\-_£{}[\]!*|\/\\:.;@#$%^&+=])(?=\S+$).{8,}$/;
 
     /**
      * validates whether the current value of the control is before the given date or not

--- a/frontend/src/app/core/services/oc-validators.ts
+++ b/frontend/src/app/core/services/oc-validators.ts
@@ -10,7 +10,7 @@ import {isTrue} from '../util/helper';
 import {Observable} from 'rxjs/Observable';
 
 export class OCValidators {
-    public static readonly PASSWORD_REGEX: RegExp = /^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[\-_£{}[\]!*|\/\\:.;@#$%^&+=])(?=\S+$).{8,}$/;
+    public static readonly PASSWORD_REGEX: RegExp = /^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[\-_£{}[\]!*|\/\\:.;?@#$%^&+=])(?=\S+$).{8,}$/;
 
     /**
      * validates whether the current value of the control is before the given date or not


### PR DESCRIPTION
This closes #375 

Summary of changes:
- ​extended the list of special characters in the password validation regex with the following chars: 
`-_£{}[]!*#/\:.;` Feel free to test the regex: https://regexr.com/3lnnr

I made sure to:
- [x] Add and / or update tests
- [x] Run the code formatter (`CTRL + ALT + L`)
- [x] Update any documentation (javadoc, domain model, erd, ...)
- [x] Follow the contribution guidelines
- [x] Update CI script and configs on Jenkins (`Jenkinsfile`, `auth0.yml`, `application.yml`, etc.)

Please review @M4R1KU / cc: @outcobra/developers.